### PR TITLE
Add migration and install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ BlockHead is a simple web interface for managing multiple websites on a single s
 7. **Backing up sites**
    - Click `Backup` next to a domain to download a zip archive of the site's files and generated config.
 
+## Migrating to a new server
+
+BlockHead ships with a small utility to assist when moving to a fresh machine.
+
+1. On the **old** server export a full backup:
+
+   ```bash
+   node scripts/migrate.js export blockhead-backup.zip
+   ```
+
+   This archive contains `sites.json`, generated Nginx configs and the content
+   of each site directory.
+
+2. Copy the archive to the **new** server and run the installation script:
+
+   ```bash
+   ./scripts/install.sh
+   ```
+
+3. Import the backup on the new machine:
+
+   ```bash
+   node scripts/migrate.js import blockhead-backup.zip
+   ```
+
+The server can then be started with `node server.js` as usual. Verify that Nginx
+config files are in place and reload Nginx if required.
+
 ## Warning
 
 This project is intended for home lab or educational use. Running arbitrary Git repositories on a public server can be dangerous. Always review code before deploying.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "archiver": "^7.0.1",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
+        "extract-zip": "^2.0.1",
         "simple-git": "^3.28.0"
       }
     },
@@ -55,6 +56,26 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -513,6 +534,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -618,11 +648,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -749,6 +808,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -1222,6 +1296,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1248,6 +1328,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1722,6 +1812,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1854,6 +1951,25 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zip-stream": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "archiver": "^7.0.1",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
-    "simple-git": "^3.28.0"
+    "simple-git": "^3.28.0",
+    "extract-zip": "^2.0.1"
   }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Basic installation script for a new BlockHead server.
+# Installs Node.js, Nginx, and project dependencies.
+# Run as root or with sudo privileges on the target machine.
+
+set -e
+
+# Update package index
+sudo apt-get update
+
+# Install system packages
+sudo apt-get install -y nodejs npm nginx git
+
+# Install Node.js dependencies for BlockHead
+npm install
+
+# Create directories if they don't exist
+mkdir -p backups generated_configs
+
+echo "Installation complete. Start the server with 'node server.js'"

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Migrate utility for BlockHead.
+ *
+ * Usage:
+ *   node scripts/migrate.js export <archive.zip>
+ *   node scripts/migrate.js import <archive.zip>
+ *
+ * The export command creates a zip containing sites.json, generated configs,
+ * and all site directories. The import command extracts the archive to the
+ * current project directory.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const archiver = require('archiver');
+const extract = require('extract-zip');
+
+// Paths used throughout the script
+const ROOT = path.join(__dirname, '..');
+const DATA_FILE = path.join(ROOT, 'sites.json');
+const GENERATED_DIR = path.join(ROOT, 'generated_configs');
+
+/**
+ * Create a full backup archive of BlockHead data.
+ * @param {string} target Path to the zip file to create
+ */
+async function exportBackup(target) {
+  const sites = fs.existsSync(DATA_FILE)
+    ? JSON.parse(fs.readFileSync(DATA_FILE))
+    : [];
+
+  const output = fs.createWriteStream(target);
+  const archive = archiver('zip', { zlib: { level: 9 } });
+
+  archive.pipe(output);
+
+  // Include site metadata
+  if (fs.existsSync(DATA_FILE)) {
+    archive.file(DATA_FILE, { name: 'sites.json' });
+  }
+
+  // Include generated nginx configs
+  if (fs.existsSync(GENERATED_DIR)) {
+    archive.directory(GENERATED_DIR, 'generated_configs');
+  }
+
+  // Include contents of each site's root directory
+  for (const site of sites) {
+    if (fs.existsSync(site.root)) {
+      const base = path.basename(site.root);
+      archive.directory(site.root, path.join('sites', base));
+    }
+  }
+
+  await archive.finalize();
+  console.log(`Backup created at ${target}`);
+}
+
+/**
+ * Restore BlockHead data from a backup archive.
+ * @param {string} source Path to the zip file to extract
+ */
+async function importBackup(source) {
+  await extract(source, { dir: ROOT });
+  console.log('Backup imported. Review nginx configs and site directories.');
+}
+
+async function main() {
+  const [mode, file] = process.argv.slice(2);
+  if (!mode || !file) {
+    console.log('Usage: node scripts/migrate.js <export|import> <archive.zip>');
+    process.exit(1);
+  }
+
+  if (mode === 'export') {
+    await exportBackup(file);
+  } else if (mode === 'import') {
+    await importBackup(file);
+  } else {
+    console.error('Unknown mode:', mode);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add migration utility to export/import a full backup
- add install script for setting up a new BlockHead server
- document migration workflow in README
- include extract-zip dependency

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a1c518e608328869768c02d896f31