### PR TITLE
Handle missing nginx directories

### DIFF
--- a/scripts/enable_site.sh
+++ b/scripts/enable_site.sh
@@ -23,6 +23,11 @@ if [ ! -f "$SOURCE" ]; then
   exit 1
 fi
 
+# Ensure nginx directory structure exists. On a fresh install the
+# /etc/nginx/sites-available and sites-enabled folders may be missing.
+# mkdir -p creates them if necessary and does nothing if they already exist.
+sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+
 # Copy config to nginx directory
 sudo cp "$SOURCE" "$TARGET"
 # Create or update symlink in sites-enabled


### PR DESCRIPTION
## Summary
- create nginx directories if missing in `enable_site.sh`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b31c7aba88328a22625633c7e5d3a