### PR TITLE
Avoid npm installation when NodeSource present

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,8 +8,8 @@ set -e
 # Update package index
 sudo apt-get update
 
-# Install system packages
-sudo apt-get install -y nodejs npm nginx git
+# Install system packages. NodeSource's nodejs already includes npm.
+sudo apt-get install -y nodejs nginx git
 
 # Install Node.js dependencies for BlockHead
 npm install


### PR DESCRIPTION
## Summary
- update package install line in `install.sh` so npm isn't separately installed when NodeSource's nodejs is present
- document that NodeSource's nodejs already bundles npm

## Testing
- `bash scripts/install.sh`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bb7805e608328aa3cacda99b3a6bf