### PR TITLE
Add diagnostic checks and repair script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ BlockHead is a simple web interface for managing multiple websites on a single s
 - Download a zip backup of any site
 - View the generated Nginx config for each site directly from the web UI
 - Modern Bootstrap-based interface for easy management
+- Diagnostic status checks displayed as traffic light indicators
 
 ## Getting Started
 
@@ -97,6 +98,18 @@ sudo chown $(whoami):$(whoami) /var/www
 Running the installation script (`./scripts/install.sh`) performs these steps
 automatically. After adjusting permissions, retry adding the site through the
 web interface.
+
+### Site shows as down
+
+The main page now includes a traffic light indicator for each domain. If a site
+appears in red or yellow, click the **Fix** button or run the helper script
+
+```bash
+sudo ./scripts/fix_site.sh your-domain
+```
+
+This copies the generated config into `/etc/nginx`, enables the site and
+reloads nginx.
 
 ## Warning
 

--- a/public/style.css
+++ b/public/style.css
@@ -18,3 +18,24 @@ th, td {
 .instructions {
   font-size: 0.9rem;
 }
+
+/* Small traffic light indicators used for site status */
+.status-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+
+.status-dot.ok {
+  background-color: #28a745; /* green */
+}
+
+.status-dot.warning {
+  background-color: #ffc107; /* yellow */
+}
+
+.status-dot.error {
+  background-color: #dc3545; /* red */
+}

--- a/scripts/fix_site.sh
+++ b/scripts/fix_site.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Attempt to repair a BlockHead site by re-enabling its nginx configuration.
+# Usage: sudo ./scripts/fix_site.sh <domain>
+# This script copies the generated config for the given domain into
+# /etc/nginx/sites-available, ensures a symlink exists in sites-enabled,
+# and reloads nginx. It assumes BlockHead has already generated the config
+# under generated_configs/<domain>.
+
+set -e
+
+DOMAIN="$1"
+if [ -z "$DOMAIN" ]; then
+  echo "Usage: sudo ./scripts/fix_site.sh <domain>" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(dirname "$0")/.."
+CONFIG="$ROOT_DIR/generated_configs/$DOMAIN"
+TARGET="/etc/nginx/sites-available/$DOMAIN"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Generated config $CONFIG not found. Use the web UI to recreate it." >&2
+  exit 1
+fi
+
+# Copy the config file into nginx and enable it
+sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+sudo cp "$CONFIG" "$TARGET"
+sudo ln -sf "$TARGET" "/etc/nginx/sites-enabled/$DOMAIN"
+
+# Reload nginx so changes take effect
+sudo systemctl reload nginx
+
+echo "Site $DOMAIN repaired and nginx reloaded."

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,12 +37,27 @@
     </div>
     <a class="btn btn-success mb-3" href="/new">Add New Site</a>
     <table class="table table-bordered table-striped">
-        <tr><th>Domain</th><th>Repository</th><th>Root</th><th>Actions</th></tr>
+        <tr>
+            <th>Domain</th>
+            <th>Repository</th>
+            <th>Root</th>
+            <th>Status</th>
+            <th>Actions</th>
+        </tr>
         <% sites.forEach(function(site){ %>
         <tr>
             <td><%= site.domain %></td>
             <td><%= site.repo %></td>
             <td><%= site.root %></td>
+            <td>
+                <span class="status-dot <%= site.status.level %>" title="<%= site.status.message %>"></span>
+                <% if (site.status.level !== 'ok') { %>
+                <form action="/fix" method="post" style="display:inline">
+                    <input type="hidden" name="domain" value="<%= site.domain %>" />
+                    <button type="submit" class="btn btn-warning btn-sm">Fix</button>
+                </form>
+                <% } %>
+            </td>
             <td>
                 <form action="/update" method="post" style="display:inline">
                     <input type="hidden" name="domain" value="<%= site.domain %>" />


### PR DESCRIPTION
## Summary
- monitor each configured site via HTTP and show status on index
- add small traffic light indicator and Fix button in the UI
- implement `fix_site.sh` to repair nginx configs
- expose `/fix` endpoint to run the repair script
- mention diagnostic feature and troubleshooting steps in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c7b4982bc8328bc199c25d4f60c2a