### PR TITLE
Add advanced console log panel

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -39,3 +39,12 @@ th, td {
 .status-dot.error {
   background-color: #dc3545; /* red */
 }
+
+/* Console log panel styles */
+#log-panel {
+  background-color: #fdfdfd;
+  border: 1px solid #ccc;
+}
+#logs {
+  font-size: 0.8rem;
+}

--- a/server.js
+++ b/server.js
@@ -17,6 +17,32 @@ const app = express();
 const PORT = 3000; // Change to 80 if running as root for HTTP
 const DATA_FILE = path.join(__dirname, 'sites.json');
 
+// --------------------------------------
+// Simple in-memory log store used by the
+// Advanced console panel in the UI. Each
+// log entry captures the level, message
+// and timestamp. The last 200 entries are
+// kept in memory.
+// --------------------------------------
+const logs = [];
+const origLog = console.log;
+const origError = console.error;
+
+// Override console methods so that every
+// call is recorded for later viewing via
+// the /logs endpoint.
+console.log = (...args) => {
+  origLog(...args);
+  logs.push({ level: 'log', message: args.join(' '), time: new Date().toISOString() });
+  if (logs.length > 200) logs.shift();
+};
+
+console.error = (...args) => {
+  origError(...args);
+  logs.push({ level: 'error', message: args.join(' '), time: new Date().toISOString() });
+  if (logs.length > 200) logs.shift();
+};
+
 // Determine the IP address used for the "View via IP" links. If the
 // SERVER_IP environment variable is set it takes precedence. Otherwise
 // we try to detect a non-internal IPv4 address so the user sees the
@@ -40,6 +66,12 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Endpoint used by the front-end advanced panel
+// to retrieve recent log messages as JSON.
+app.get('/logs', (req, res) => {
+  res.json(logs);
+});
 
 // Utility function to load site data from JSON file
 function loadSites() {

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -79,5 +79,6 @@ npm install
     <!-- Easy navigation back to the main page -->
     <a href="/" class="btn btn-link mt-4">Back to Manager</a>
     </div>
+<%- include("partials/log-panel") %>
 </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -84,5 +84,6 @@
         <% }) %>
     </table>
     </div>
+<%- include("partials/log-panel") %>
 </body>
 </html>

--- a/views/new.ejs
+++ b/views/new.ejs
@@ -48,5 +48,6 @@
     <!-- Easy navigation back to the site list -->
     <a href="/" class="btn btn-link">Back to List</a>
     </div>
+<%- include("partials/log-panel") %>
 </body>
 </html>

--- a/views/partials/log-panel.ejs
+++ b/views/partials/log-panel.ejs
@@ -1,0 +1,25 @@
+<div class="container mt-4">
+  <button id="toggle-logs" class="btn btn-sm btn-secondary">Advanced</button>
+  <div id="log-panel" class="mt-2" style="display:none;">
+    <pre id="logs" class="bg-light p-2" style="height:150px; overflow:auto;"></pre>
+  </div>
+</div>
+<script>
+// Toggle log panel visibility and fetch log data on demand
+const btn = document.getElementById('toggle-logs');
+const panel = document.getElementById('log-panel');
+const logPre = document.getElementById('logs');
+btn.addEventListener('click', () => {
+  if (panel.style.display === 'none') {
+    fetch('/logs')
+      .then(res => res.json())
+      .then(data => {
+        // Join log entries into a single text block
+        logPre.textContent = data.map(l => `[${l.time}] ${l.message}`).join('\n');
+        panel.style.display = 'block';
+      });
+  } else {
+    panel.style.display = 'none';
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- store recent console output in memory and expose via `/logs`
- show/hide a log panel on all pages through a new partial
- style the console panel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cd606109883288e3dd414c456af6b