### PR TITLE
Add run/stop command feature

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -48,3 +48,10 @@ th, td {
 #logs {
   font-size: 0.8rem;
 }
+
+/* Make the small command input fit nicely inline with buttons */
+.run-form input[type="text"] {
+  width: 140px;
+  display: inline-block;
+  margin-right: 4px;
+}

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -76,6 +76,9 @@ npm install
         <li>Keep Node.js running in the background with a tool such as <code>screen</code> or <code>pm2</code>.</li>
     </ul>
 
+    <h3>8. Run and Stop commands</h3>
+    <p class="mb-2">On the main page each site row includes a small text box. Enter the command you wish to run, e.g. <code>npm start</code> or <code>python app.py</code>, then click <em>Run</em>. Use <em>Stop</em> to terminate the process.</p>
+
     <!-- Easy navigation back to the main page -->
     <a href="/" class="btn btn-link mt-4">Back to Manager</a>
     </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,6 +23,7 @@
             <li><strong>View via IP</strong> &ndash; open the site using the server IP (<%= serverIp %>).</li>
             <li><strong>View Site</strong> &ndash; open the site using its domain name.</li>
             <li><strong>Delete</strong> &ndash; remove the entry here (does not delete files).</li>
+            <li><strong>Run/Stop</strong> &ndash; run a custom command for the site, e.g. <code>npm start</code>, and stop it when needed.</li>
         </ul>
         <p class="mt-2">
             After adding a site, enable it with the helper script:
@@ -34,6 +35,7 @@
             Create an <strong>A record</strong> pointing to <code><%= serverIp %></code>.
             Once DNS has propagated you can view the site using the buttons below.
         </p>
+        <p class="mb-0">To start a site manually, enter a command such as <code>npm start</code> and press <em>Run</em>. Use <em>Stop</em> to terminate it.</p>
     </div>
     <a class="btn btn-success mb-3" href="/new">Add New Site</a>
     <!-- Quick link to the comprehensive help page -->
@@ -78,6 +80,15 @@
                 <form action="/delete" method="post" style="display:inline" onsubmit="return confirm('Delete <%= site.domain %>?')">
                     <input type="hidden" name="domain" value="<%= site.domain %>" />
                     <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+                <form action="/run" method="post" class="run-form mt-1 d-inline">
+                    <input type="hidden" name="domain" value="<%= site.domain %>" />
+                    <input type="text" name="cmd" placeholder="command" class="form-control form-control-sm" />
+                    <button type="submit" class="btn btn-success btn-sm">Run</button>
+                </form>
+                <form action="/stop" method="post" class="mt-1 d-inline">
+                    <input type="hidden" name="domain" value="<%= site.domain %>" />
+                    <button type="submit" class="btn btn-warning btn-sm">Stop</button>
                 </form>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- allow running and stopping custom commands for each site
- add forms on the index page to enter a command and run/stop it
- show quick usage instructions in the help page and index page
- style the command input box

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cd9661cb483288e62747877d5782d