### PR TITLE
Add port-based proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ For a detailed walkthrough see the in-app help page at `/help` once the server i
 3. **Add your first site**
    - Click `Add New Site`
    - Provide the domain (e.g., `example.com`), the Git repo URL, and the directory where the site should live on disk.
+   - If the app listens on a specific port (e.g., `3001`), enter it in the **Application Port** field.
    - The app clones the repository and creates a config snippet in `generated_configs/`.
    - If the project contains a `package.json`, BlockHead automatically runs `npm install` and then starts the app using `npm start`.
 

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -40,7 +40,7 @@ npm install
     <h3>3. Add your first site</h3>
     <ol>
         <li>Click <em>Add New Site</em> in the menu.</li>
-        <li>Fill in the domain, Git repository URL and site root path.</li>
+        <li>Fill in the domain, Git repository URL and site root path. Enter the application's port if it runs on one.</li>
         <li>BlockHead attempts to configure Nginx for you automatically.</li>
         <li>If you still see the default Nginx page, run:
             <pre><code>sudo ./scripts/enable_site.sh your-domain</code></pre>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -16,7 +16,7 @@
     <div class="alert alert-info instructions">
         <p class="mb-1"><strong>How to manage your sites:</strong></p>
         <ul class="mb-0">
-            <li><strong>Add New Site</strong> &ndash; register a domain and clone its repository.</li>
+            <li><strong>Add New Site</strong> &ndash; register a domain and clone its repository. Specify the port if the app is dynamic.</li>
             <li><strong>Pull Latest</strong> &ndash; fetch updates from the site's Git repository.</li>
             <li><strong>Backup</strong> &ndash; download a zip of the site files and nginx config.</li>
             <li><strong>View Config</strong> &ndash; open the generated nginx server block.</li>
@@ -46,6 +46,7 @@
             <th>Domain</th>
             <th>Repository</th>
             <th>Root</th>
+            <th>Port</th>
             <th>Status</th>
             <th>Actions</th>
         </tr>
@@ -54,6 +55,7 @@
             <td><%= site.domain %></td>
             <td><%= site.repo %></td>
             <td><%= site.root %></td>
+            <td><%= site.port || '' %></td>
             <td>
                 <span class="status-dot <%= site.status.level %>" title="<%= site.status.message %>"></span>
                 <% if (site.status.level !== 'ok') { %>

--- a/views/new.ejs
+++ b/views/new.ejs
@@ -43,6 +43,12 @@
                 <input class="form-control" type="text" name="root" required>
             </label>
         </div>
+        <div class="mb-3">
+            <label class="form-label">Application Port
+                <input class="form-control" type="number" name="port" value="<%= defaultPort %>" />
+                <div class="form-text">If your app runs on a specific port (e.g. <code>3001</code>), enter it here. Leave blank for a static site.</div>
+            </label>
+        </div>
         <button type="submit" class="btn btn-primary">Create</button>
     </form>
     <!-- Easy navigation back to the site list -->


### PR DESCRIPTION
## Summary
- allow apps to specify their own port when added
- proxy nginx traffic to dynamic apps using that port
- expose a suggested port in the add site form
- display the port in the site list
- document the new behaviour in README and help page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cdce72a308328928e8d0e73eca16a