### PR TITLE
Add configurable start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For a detailed walkthrough see the in-app help page at `/help` once the server i
    - Click `Add New Site`
    - Provide the domain (e.g., `example.com`), the Git repo URL, and the directory where the site should live on disk.
    - If the app listens on a specific port (e.g., `3001`), enter it in the **Application Port** field.
+   - Optionally provide a **Start Command** to run after cloning, such as `./scripts/rpi_bidfinder.sh -p 4000`.
    - The app clones the repository and creates a config snippet in `generated_configs/`.
    - If the project contains a `package.json`, BlockHead automatically runs `npm install` and then starts the app using `npm start`.
 

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -41,6 +41,7 @@ npm install
     <ol>
         <li>Click <em>Add New Site</em> in the menu.</li>
         <li>Fill in the domain, Git repository URL and site root path. Enter the application's port if it runs on one.</li>
+        <li>Optionally specify a <em>Start Command</em> to launch the app after cloning (e.g. <code>python app.py 8080 --production</code>).</li>
         <li>BlockHead attempts to configure Nginx for you automatically.</li>
         <li>If you still see the default Nginx page, run:
             <pre><code>sudo ./scripts/enable_site.sh your-domain</code></pre>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -47,6 +47,7 @@
             <th>Repository</th>
             <th>Root</th>
             <th>Port</th>
+            <th>Start Command</th>
             <th>Status</th>
             <th>Actions</th>
         </tr>
@@ -56,6 +57,7 @@
             <td><%= site.repo %></td>
             <td><%= site.root %></td>
             <td><%= site.port || '' %></td>
+            <td><%= site.cmd || '' %></td>
             <td>
                 <span class="status-dot <%= site.status.level %>" title="<%= site.status.message %>"></span>
                 <% if (site.status.level !== 'ok') { %>
@@ -86,7 +88,7 @@
                 </form>
                 <form action="/run" method="post" class="run-form mt-1 d-inline">
                     <input type="hidden" name="domain" value="<%= site.domain %>" />
-                    <input type="text" name="cmd" placeholder="command" class="form-control form-control-sm" />
+                    <input type="text" name="cmd" placeholder="command" value="<%= site.cmd || '' %>" class="form-control form-control-sm" />
                     <button type="submit" class="btn btn-success btn-sm">Run</button>
                 </form>
                 <form action="/stop" method="post" class="mt-1 d-inline">

--- a/views/new.ejs
+++ b/views/new.ejs
@@ -49,6 +49,12 @@
                 <div class="form-text">If your app runs on a specific port (e.g. <code>3001</code>), enter it here. Leave blank for a static site.</div>
             </label>
         </div>
+        <div class="mb-3">
+            <label class="form-label">Start Command
+                <input class="form-control" type="text" name="cmd" placeholder="e.g. ./scripts/start.sh" />
+                <div class="form-text">Command to launch the application after cloning. Leave blank to use <code>npm start</code> if available.</div>
+            </label>
+        </div>
         <button type="submit" class="btn btn-primary">Create</button>
     </form>
     <!-- Easy navigation back to the site list -->


### PR DESCRIPTION
## Summary
- allow sites to specify a custom command when created
- store the command in `sites.json`
- run the custom command when creating or updating a site
- pass site port to commands via `process.env.PORT`
- show start command in UI and help docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d0aee2fcc832889efe7fbe852d88f