### PR TITLE
feat: add SSL configuration UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ server.log
 generated_configs/
 sites.json
 backups/
+ssl/

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -19,6 +19,7 @@
             <li><strong>Add New Site</strong> &ndash; register a domain and clone its repository. Specify the port if the app is dynamic.</li>
             <li><strong>Pull Latest</strong> &ndash; fetch updates from the site's Git repository.</li>
             <li><strong>Backup</strong> &ndash; download a zip of the site files and nginx config.</li>
+            <li><strong>Configure SSL</strong> &ndash; upload certificates for HTTPS.</li>
             <li><strong>View Config</strong> &ndash; open the generated nginx server block.</li>
             <li><strong>View via IP</strong> &ndash; open the site using the server IP (<%= serverIp %>).</li>
             <li><strong>View Site</strong> &ndash; open the site using its domain name.</li>
@@ -76,6 +77,8 @@
                     <input type="hidden" name="domain" value="<%= site.domain %>" />
                     <button type="submit" class="btn btn-secondary btn-sm">Backup</button>
                 </form>
+                <!-- Open SSL configuration page for this domain -->
+                <a class="btn btn-warning btn-sm" href="/ssl/<%= site.domain %>">Configure SSL</a>
                 <!-- Link to view the generated nginx config -->
                 <a class="btn btn-info btn-sm" href="/config/<%= site.domain %>" target="_blank">View Config</a>
                 <!-- Open the site via the server's IP address -->

--- a/views/ssl.ejs
+++ b/views/ssl.ejs
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Configure SSL</title>
+    <!-- Bootstrap for consistent styling -->
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <div class="container my-4">
+    <h1 class="mb-4">Configure SSL for <%= domain %></h1>
+    <!-- Instruction block explaining how to enter certificate details -->
+    <div class="alert alert-info instructions">
+        <p class="mb-1"><strong>Install a certificate for HTTPS:</strong></p>
+        <ol class="mb-2">
+            <li>Paste the entire certificate including the <code>-----BEGIN CERTIFICATE-----</code> and <code>-----END CERTIFICATE-----</code> lines.</li>
+            <li>Paste the matching private key starting with <code>-----BEGIN PRIVATE KEY-----</code>.</li>
+            <li>Example: to obtain a free Let's Encrypt certificate you might run <code>certbot certonly --manual -d <%= domain %></code> and copy the generated files here.</li>
+        </ol>
+        <p class="mb-0">After saving, BlockHead will update the Nginx config and attempt to reload the site.</p>
+    </div>
+    <form action="/ssl/<%= domain %>" method="post">
+        <div class="mb-3">
+            <label class="form-label">Certificate
+                <textarea class="form-control" name="cert" rows="6" placeholder="-----BEGIN CERTIFICATE-----\n..."></textarea>
+            </label>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Private Key
+                <textarea class="form-control" name="key" rows="6" placeholder="-----BEGIN PRIVATE KEY-----\n..."></textarea>
+            </label>
+        </div>
+        <button type="submit" class="btn btn-primary">Install</button>
+        <a href="/" class="btn btn-link">Back to List</a>
+    </form>
+    </div>
+<%- include("partials/log-panel") %>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow users to configure SSL certificates per site through new Configure SSL button
- store uploaded certs/keys and regenerate nginx config with SSL directives
- provide step-by-step SSL install page with example placeholders

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dcd6102388328b6114f8134ccffba