### PR TITLE
Refactor nginx configuration into simple and expert modes

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,7 +42,7 @@
     <a class="btn btn-success mb-3" href="/new">Add New Site</a>
     <!-- Quick link to the comprehensive help page -->
     <a class="btn btn-info mb-3 ms-2" href="/help">Help</a>
-    <!-- Open the global nginx configuration editor -->
+    <!-- Open the nginx configuration UI (simple mode by default) -->
     <a class="btn btn-outline-primary mb-3 ms-2" href="/nginx">Nginx Config</a>
     <table class="table table-bordered table-striped">
         <tr>

--- a/views/nginx-expert.ejs
+++ b/views/nginx-expert.ejs
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Nginx Configuration - Expert Mode</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <div class="container my-4">
+        <h1 class="mb-4">Nginx Configuration <small class="text-muted">Expert Mode</small></h1>
+
+        <!-- Dropdown to switch between site-specific configs and the global nginx.conf -->
+        <div class="mb-3">
+            <label class="form-label">Edit configuration for:</label>
+            <select class="form-select" onchange="location.href='/nginx/expert?site=' + this.value">
+                <option value="" <%= !domain ? 'selected' : '' %>>Global nginx.conf</option>
+                <% sites.forEach(s => { %>
+                <option value="<%= s.domain %>" <%= domain===s.domain ? 'selected' : '' %>><%= s.domain %></option>
+                <% }) %>
+            </select>
+        </div>
+
+        <!-- Display the file path being edited so advanced users know the exact location -->
+        <p class="text-muted">Editing: <code><%= filePath %></code></p>
+
+        <!-- Confirmation message displayed after successful save -->
+        <% if (saved) { %>
+            <div class="alert alert-success">Configuration saved and reload attempted.</div>
+        <% } %>
+        <% if (!config) { %>
+            <!-- Alert the user if the config file could not be read -->
+            <div class="alert alert-warning">No configuration data found.</div>
+        <% } %>
+
+        <!-- Raw textarea editor for nginx configuration -->
+        <form method="post" action="/nginx/expert">
+            <input type="hidden" name="domain" value="<%= domain %>">
+            <textarea name="config" class="form-control" rows="20"><%- config %></textarea>
+            <button type="submit" class="btn btn-primary mt-3">Save</button>
+            <a href="/nginx?site=<%= domain %>" class="btn btn-secondary mt-3">Simple Mode</a>
+            <a href="/" class="btn btn-secondary mt-3">Back</a>
+        </form>
+    </div>
+</body>
+</html>

--- a/views/nginx.ejs
+++ b/views/nginx.ejs
@@ -1,27 +1,50 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Nginx Configuration</title>
+    <title>Nginx Configuration - Simple Mode</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/style.css">
 </head>
 <body>
     <div class="container my-4">
-        <h1 class="mb-4">Nginx Configuration</h1>
-        <!-- When redirected after a save, show a confirmation message -->
+        <h1 class="mb-4">Nginx Configuration <small class="text-muted">Simple Mode</small></h1>
+
+        <!-- Show success message after saving settings -->
         <% if (saved) { %>
-            <div class="alert alert-success">Configuration saved and reload attempted.</div>
+            <div class="alert alert-success">Settings saved.</div>
         <% } %>
-        <% if (!config) { %>
-            <!-- Alert the user if the config file could not be read -->
-            <div class="alert alert-warning">No configuration data found.</div>
+
+        <% if (!sites.length) { %>
+            <!-- Warn when no sites are configured so there is nothing to edit -->
+            <div class="alert alert-warning">No sites configured.</div>
+        <% } else { %>
+            <!-- Dropdown allows switching between different site configurations -->
+            <div class="mb-3">
+                <label class="form-label">Configure site:</label>
+                <select class="form-select" onchange="location.href='/nginx?site=' + this.value">
+                    <% sites.forEach(s => { %>
+                    <option value="<%= s.domain %>" <%= site && site.domain===s.domain ? 'selected' : '' %>><%= s.domain %></option>
+                    <% }) %>
+                </select>
+            </div>
+
+            <!-- Form exposes basic nginx-related settings stored for each site -->
+            <form method="post" action="/nginx">
+                <input type="hidden" name="domain" value="<%= site.domain %>">
+                <div class="mb-3">
+                    <label class="form-label">Root Directory</label>
+                    <input type="text" class="form-control" name="root" value="<%= site.root %>">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Proxy Port (leave blank for static)</label>
+                    <input type="text" class="form-control" name="port" value="<%= site.port || '' %>">
+                </div>
+                <button type="submit" class="btn btn-primary">Save</button>
+                <a href="/nginx/expert?site=<%= site.domain %>" class="btn btn-secondary">Expert Mode</a>
+                <a href="/" class="btn btn-secondary">Back</a>
+            </form>
         <% } %>
-        <!-- Simple textarea editor for nginx.conf -->
-        <form method="post" action="/nginx">
-            <textarea name="config" class="form-control" rows="20"><%- config %></textarea>
-            <button type="submit" class="btn btn-primary mt-3">Save</button>
-            <a href="/" class="btn btn-secondary mt-3">Back</a>
-        </form>
     </div>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Split nginx configuration UI into simple and expert modes
- Simple mode lets users tweak site root and port with dropdown site selector
- Expert mode exposes raw config editor and shows the file path being edited

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd61ebad88328b70729100f870048