### PR TITLE
Use absolute paths for site scripts

### DIFF
--- a/scripts/enable_site.sh
+++ b/scripts/enable_site.sh
@@ -8,6 +8,10 @@
 
 set -e
 
+# Determine the absolute path to this script's directory so path references
+# work regardless of the caller's current working directory.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Abort unless running with root privileges since we write to /etc/nginx.
 if [ "$EUID" -ne 0 ]; then
   echo "This script must be run as root" >&2
@@ -33,7 +37,7 @@ if [ -z "$DOMAIN" ]; then
   exit 1
 fi
 
-CONFIG_DIR="$(dirname "$0")/../generated_configs"
+CONFIG_DIR="$DIR/../generated_configs"
 SOURCE="$CONFIG_DIR/$DOMAIN"
 TARGET="/etc/nginx/sites-available/$DOMAIN"
 

--- a/scripts/fix_site.sh
+++ b/scripts/fix_site.sh
@@ -14,8 +14,12 @@ if [ -z "$DOMAIN" ]; then
   exit 1
 fi
 
-ROOT_DIR="$(dirname "$0")/.."
-CONFIG="$ROOT_DIR/generated_configs/$DOMAIN"
+# Determine the absolute path to this script's directory so the generated
+# configuration can be found regardless of the caller's working directory.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Build the path to the generated nginx configuration for this domain.
+CONFIG="$DIR/../generated_configs/$DOMAIN"
 TARGET="/etc/nginx/sites-available/$DOMAIN"
 
 if [ ! -f "$CONFIG" ]; then


### PR DESCRIPTION
## Summary
- resolve generated config paths using script directory
- harden repair script to locate config independent of working dir

## Testing
- `bash -n scripts/enable_site.sh`
- `bash -n scripts/fix_site.sh`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688de6aa797083288d5fdd8dcc9d7f3d