### PR TITLE
Handle nginx reload errors in expert mode

### DIFF
--- a/views/nginx-expert.ejs
+++ b/views/nginx-expert.ejs
@@ -23,6 +23,11 @@
         <!-- Display the file path being edited so advanced users know the exact location -->
         <p class="text-muted">Editing: <code><%= filePath %></code></p>
 
+        <!-- Error message shown when nginx fails to reload after saving -->
+        <% if (error) { %>
+            <div class="alert alert-danger"><%= error %></div>
+        <% } %>
+
         <!-- Confirmation message displayed after successful save -->
         <% if (saved) { %>
             <div class="alert alert-success">Configuration saved and reload attempted.</div>


### PR DESCRIPTION
## Summary
- Return error info from expert config reloads so UI shows failure details
- Display reload failures in nginx expert editor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688de8f0392c8328a1e8d4607bcd4a01