### PR TITLE
feat: auto install python deps

### DIFF
--- a/server.js
+++ b/server.js
@@ -493,12 +493,25 @@ app.post('/new', async (req, res) => {
     // dependencies and launch the app automatically. This assumes the
     // project defines a standard "start" script.
     const pkgPath = path.join(root, 'package.json');
+    // Look for a Python requirements file so we can handle Python projects too
+    const requirementsPath = path.join(root, 'requirements.txt');
     if (fs.existsSync(pkgPath)) {
       console.log(`Installing dependencies for ${domain}`);
       try {
         await runCommand('npm install', root);
       } catch (installErr) {
         console.error('Install failed:', installErr);
+      }
+    }
+
+    if (fs.existsSync(requirementsPath)) {
+      // When a Python project is detected, prepare a virtual environment and
+      // install its dependencies so the app has everything it needs to run.
+      console.log(`Installing Python dependencies for ${domain}`);
+      try {
+        await runCommand('python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements.txt', root);
+      } catch (pyInstallErr) {
+        console.error('Python install failed:', pyInstallErr);
       }
     }
 

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -43,6 +43,8 @@ npm install
         <li>Fill in the domain, Git repository URL and site root path. Enter the application's port if it runs on one.</li>
         <li>If the root folder already contains files, either delete it with <code>sudo rm -rf /path/to/site</code> or tick <em>Overwrite existing directory</em> on the form.</li>
         <li>Optionally specify a <em>Start Command</em> to launch the app after cloning (e.g. <code>python app.py 8080 --production</code>).</li>
+        <!-- BlockHead now handles dependency installation for common languages -->
+        <li>If your repository includes a <code>package.json</code> or <code>requirements.txt</code>, BlockHead automatically installs Node or Python dependencies for you.</li>
         <li>BlockHead attempts to configure Nginx automatically using <code>sudo</code>. This requires the server process to have passwordless sudo access.</li>
         <li>If the step fails or you still see the default Nginx page, run:
             <pre><code>sudo ./scripts/enable_site.sh your-domain</code></pre>


### PR DESCRIPTION
## Summary
- install Python requirements in virtual environment when cloning new site
- document automatic dependency setup for Node and Python apps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dedbf535c8328a693e43040de5e8d