### PR TITLE
feat: integrate GoDaddy DNS automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ For a detailed walkthrough see the in-app help page at `/help` once the server i
      Replace `example.com` with your domain name.
 
 5. **Configure your domain in GoDaddy**
-   - Log into GoDaddy and edit the DNS records for your domain.
-   - Create an `A` record that points to your home server's static IP (`193.237.136.211`).
-   - Allow time for DNS propagation.
+    - On the main page you can enter your GoDaddy API key and secret next to a domain and press **Setup DNS** to automatically create an `A` record pointing to your server's IP (`193.237.136.211`).
+    - If you prefer not to use the API, log into GoDaddy manually and create an `A` record for the domain pointing to the same IP.
+    - Allow time for DNS propagation regardless of the method used.
 
 6. **Updating sites**
    - On the main page, click `Pull Latest` next to a domain to run `git pull origin main` in the site's directory.

--- a/scripts/godaddy.js
+++ b/scripts/godaddy.js
@@ -1,0 +1,50 @@
+const https = require('https');
+
+/**
+ * Create or update the root A record for a domain via GoDaddy's API.
+ * The function performs a simple HTTP PUT request using the provided
+ * credentials. Only IPv4 addresses are supported for the A record.
+ *
+ * @param {string} domain - Domain name, e.g. "example.com".
+ * @param {string} ip - IPv4 address to assign to the A record.
+ * @param {string} key - GoDaddy API key.
+ * @param {string} secret - GoDaddy API secret.
+ * @returns {Promise<void>} Resolves on success or rejects with an error.
+ */
+function updateARecord(domain, ip, key, secret) {
+  return new Promise((resolve, reject) => {
+    // GoDaddy expects a JSON array of record objects even when updating a single record
+    const payload = JSON.stringify([{ data: ip, ttl: 600 }]);
+
+    const options = {
+      hostname: 'api.godaddy.com',
+      path: `/v1/domains/${domain}/records/A/@`,
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        // API authentication uses the "sso-key" scheme
+        'Authorization': `sso-key ${key}:${secret}`
+      }
+    };
+
+    const req = https.request(options, res => {
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        // GoDaddy returns 200-series codes for success
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          return resolve();
+        }
+        // Include response body to aid debugging when something goes wrong
+        reject(new Error(`GoDaddy API responded with ${res.statusCode}: ${data}`));
+      });
+    });
+
+    req.on('error', err => reject(err));
+    req.write(payload);
+    req.end();
+  });
+}
+
+module.exports = { updateARecord };

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -11,9 +11,14 @@
 </head>
 <body>
     <div class="container my-4">
-    <h1 class="mb-4">Website Manager</h1>
-    <!-- Instruction block to clearly explain how this page works -->
-    <div class="alert alert-info instructions">
+      <h1 class="mb-4">Website Manager</h1>
+      <% if (dns === '1') { %>
+      <div class="alert alert-success">DNS record created. It may take a few minutes for changes to propagate.</div>
+      <% } else if (dns === '0') { %>
+      <div class="alert alert-danger">DNS setup failed: <%= dnsError %>. Please configure the A record manually in GoDaddy.</div>
+      <% } %>
+      <!-- Instruction block to clearly explain how this page works -->
+      <div class="alert alert-info instructions">
         <p class="mb-1"><strong>How to manage your sites:</strong></p>
         <ul class="mb-0">
             <li><strong>Add New Site</strong> &ndash; register a domain and clone its repository. Specify the port if the app is dynamic.</li>
@@ -33,11 +38,9 @@
             <code>sudo ./scripts/enable_site.sh your-domain</code>
             replacing <code>your-domain</code> with the domain you added.
         </p>
-        <p class="mb-0">
-            Next, log in to GoDaddy and edit the DNS records for your domain.
-            Create an <strong>A record</strong> pointing to <code><%= serverIp %></code>.
-            Once DNS has propagated you can view the site using the buttons below.
-        </p>
+          <p class="mb-0">
+              To point your domain at this server you may either enter your GoDaddy API key and secret next to a site and press <em>Setup DNS</em>, or log in to GoDaddy and manually create an <strong>A record</strong> pointing to <code><%= serverIp %></code>. Once DNS has propagated you can view the site using the buttons below.
+          </p>
         <p class="mb-0">To start a site manually, enter a command such as <code>npm start</code> and press <em>Run</em>. Use <em>Stop</em> to terminate it.</p>
     </div>
     <a class="btn btn-success mb-3" href="/new">Add New Site</a>
@@ -97,15 +100,23 @@
                     <input type="text" name="cmd" placeholder="command" value="<%= site.cmd || '' %>" class="form-control form-control-sm" />
                     <button type="submit" class="btn btn-success btn-sm">Run</button>
                 </form>
-                <form action="/stop" method="post" class="mt-1 d-inline">
-                    <input type="hidden" name="domain" value="<%= site.domain %>" />
-                    <button type="submit" class="btn btn-warning btn-sm">Stop</button>
-                </form>
-            </td>
-        </tr>
-        <% }) %>
-    </table>
-    </div>
+                  <form action="/stop" method="post" class="mt-1 d-inline">
+                      <input type="hidden" name="domain" value="<%= site.domain %>" />
+                      <button type="submit" class="btn btn-warning btn-sm">Stop</button>
+                  </form>
+                  <!-- Optional GoDaddy DNS automation -->
+                  <form action="/dns" method="post" class="mt-1 d-inline">
+                      <input type="hidden" name="domain" value="<%= site.domain %>" />
+                      <input type="text" name="key" placeholder="API Key" class="form-control form-control-sm mb-1" />
+                      <input type="text" name="secret" placeholder="API Secret" class="form-control form-control-sm mb-1" />
+                      <button type="submit" class="btn btn-dark btn-sm">Setup DNS</button>
+                  </form>
+                  <div class="form-text">Provide GoDaddy credentials for automatic DNS. Otherwise configure records manually.</div>
+              </td>
+          </tr>
+          <% }) %>
+      </table>
+      </div>
 <%- include("partials/log-panel") %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow automatic A record creation via GoDaddy API
- expose `/dns` endpoint and UI fields to trigger DNS setup
- document manual DNS fallback instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688def2745708328913ec6018c0cfc84