### PR TITLE
feat: auto run python apps

### DIFF
--- a/views/help.ejs
+++ b/views/help.ejs
@@ -45,6 +45,7 @@ npm install
         <li>Optionally specify a <em>Start Command</em> to launch the app after cloning (e.g. <code>python app.py 8080 --production</code>).</li>
         <!-- BlockHead now handles dependency installation for common languages -->
         <li>If your repository includes a <code>package.json</code> or <code>requirements.txt</code>, BlockHead automatically installs Node or Python dependencies for you.</li>
+        <li>If a <code>requirements.txt</code> file is present and you leave <em>Start Command</em> empty, BlockHead will try to run <code>app.py</code> or <code>main.py</code> with <code>python</code>. Provide your own command to override this default.</li>
         <li>BlockHead attempts to configure Nginx automatically using <code>sudo</code>. This requires the server process to have passwordless sudo access.</li>
         <li>If the step fails or you still see the default Nginx page, run:
             <pre><code>sudo ./scripts/enable_site.sh your-domain</code></pre>


### PR DESCRIPTION
## Summary
- auto-detect common Python entry points when requirements.txt is present
- run default `python <entrypoint>` command if no custom command provided
- document Python default behavior in help page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e009ef2f48328b3082bba7d8745cb