### PR TITLE
Add manual enable hint when auto enabling site fails

### DIFF
--- a/views/nginx.ejs
+++ b/views/nginx.ejs
@@ -14,6 +14,11 @@
             <div class="alert alert-success">Settings saved.</div>
         <% } %>
 
+        <!-- Display error details when nginx reload fails -->
+        <% if (error) { %>
+            <div class="alert alert-danger"><%= error %></div>
+        <% } %>
+
         <% if (!sites.length) { %>
             <!-- Warn when no sites are configured so there is nothing to edit -->
             <div class="alert alert-warning">No sites configured.</div>


### PR DESCRIPTION
## Summary
- show nginx enable errors in the simple config view
- suggest running `sudo ./scripts/enable_site.sh <domain>` if auto enable fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e01c356ec8328a26362eedb6a1402