### PR TITLE
Handle missing server IP in test endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -991,6 +991,16 @@ app.get('/test/:domain', async (req, res) => {
 
   // Options for the HTTP request using the detected server IP but specifying the domain
   const serverIp = await getServerIp();
+  // If the IP couldn't be determined (for example due to lack of
+  // internet connectivity), return a helpful error instead of
+  // attempting a request with an undefined host.
+  if (!serverIp) {
+    return res.json({
+      ok: false,
+      error: 'Unable to determine server IP. Set SERVER_IP or check network connectivity.'
+    });
+  }
+
   const options = {
     host: serverIp,
     port: 80,


### PR DESCRIPTION
## Summary
- guard `/test/:domain` endpoint against missing IP detection and provide helpful error message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e240e9fa48328b69266a1e6703edb