### PR TITLE
Add environment reset script and setup controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ For a detailed walkthrough see the in-app help page at `/help` once the server i
 
 ## Getting Started
 
+0. **(Optional) Create a Python virtual environment**
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+   This isolates any Python tools you may install while working with BlockHead.
+
 1. **Install dependencies**
    ```bash
    npm install
@@ -71,6 +78,22 @@ For a detailed walkthrough see the in-app help page at `/help` once the server i
     - Click **Configure SSL** for your domain.
     - Paste the certificate and key or upload the relevant `.pem/.crt/.key` files or GoDaddy `.zip` bundle.
     - After installing, use the **Test SSL** button or visit `/ssl/your-domain/test` to verify the certificate.
+
+## Resetting the environment
+
+If you need to completely remove BlockHead, all hosted sites, and Nginx itself, run:
+
+```bash
+./scripts/nuke.sh
+```
+
+The main UI also exposes a **Nuclear Option** button which triggers the same script. After running it you can reinstall dependencies and Nginx with:
+
+```bash
+./scripts/install.sh
+```
+
+or use the **Setup** button on the main page.
 
 ## Migrating to a new server
 

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Completely remove Nginx, BlockHead configs, and hosted sites.
+# Use with caution: this is a destructive operation intended
+# to reset the server to a pristine state.
+
+set -e
+
+# Stop Nginx if it is running to release any locks on configuration files.
+echo "Stopping nginx..."
+sudo systemctl stop nginx 2>/dev/null || true
+
+# Purge nginx packages so they are removed from the system.
+echo "Purging nginx packages..."
+sudo apt-get purge -y nginx nginx-common nginx-core 2>/dev/null || true
+sudo apt-get autoremove -y 2>/dev/null || true
+
+# Remove nginx configuration directories.
+echo "Removing nginx configuration directories..."
+sudo rm -rf /etc/nginx
+
+# Remove all site files under /var/www which are typically
+# created by BlockHead when cloning repositories.
+echo "Removing site directories..."
+sudo rm -rf /var/www/*
+
+# Delete BlockHead generated files and configuration state.
+echo "Cleaning BlockHead data..."
+rm -rf generated_configs backups sites.json
+
+echo "Nuclear cleanup complete. You may run ./scripts/install.sh to reinstall."

--- a/server.js
+++ b/server.js
@@ -870,6 +870,36 @@ app.post('/dns', async (req, res) => {
   }
 });
 
+// -------------------------------------------------------------------
+// Setup and nuclear cleanup endpoints
+// -------------------------------------------------------------------
+
+// Run the installation script to reinstall Nginx and project dependencies.
+app.post('/setup', (req, res) => {
+  exec('bash scripts/install.sh', (err, stdout, stderr) => {
+    if (err) {
+      // Log any errors produced by the setup script so operators can debug
+      console.error('Setup error:', stderr);
+    } else {
+      console.log(stdout);
+    }
+    res.redirect('/');
+  });
+});
+
+// Destructively remove all sites and uninstall Nginx via the nuke script.
+app.post('/nuke', (req, res) => {
+  exec('bash scripts/nuke.sh', (err, stdout, stderr) => {
+    if (err) {
+      // Surface errors from the nuke script; at this point the system may be in a partial state.
+      console.error('Nuke error:', stderr);
+    } else {
+      console.log(stdout);
+    }
+    res.redirect('/');
+  });
+});
+
 // Render the SSL configuration form for a specific domain
 app.get('/ssl/:domain', (req, res) => {
   const { domain } = req.params;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -48,6 +48,13 @@
     <a class="btn btn-info mb-3 ms-2" href="/help">Help</a>
     <!-- Open the nginx configuration UI (simple mode by default) -->
     <a class="btn btn-outline-primary mb-3 ms-2" href="/nginx">Nginx Config</a>
+    <!-- Buttons to reinstall or wipe the environment entirely -->
+    <form action="/setup" method="post" class="d-inline" onsubmit="return confirm('Run setup script to reinstall Nginx and dependencies?');">
+      <button type="submit" class="btn btn-outline-secondary mb-3 ms-2">Setup</button>
+    </form>
+    <form action="/nuke" method="post" class="d-inline" onsubmit="return confirm('Remove all sites and uninstall Nginx? This cannot be undone.');">
+      <button type="submit" class="btn btn-danger mb-3 ms-2">Nuclear Option</button>
+    </form>
     <table class="table table-bordered table-striped">
         <tr>
             <th>Domain</th>


### PR DESCRIPTION
## Summary
- Provide `nuke.sh` to uninstall nginx and wipe BlockHead data
- Expose Setup and Nuclear Option buttons with server routes
- Document Python venv usage and reset instructions in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f973286e08328b37e3102e79c14eb